### PR TITLE
Clean up apt-get lists after every apt package installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,6 +92,7 @@ RUN git -c advice.detachedHead=0 clone --branch ${PYENV_VERSION} --depth 1 https
 ENV PIPX_BIN_DIR=/root/.local/bin
 ENV PATH=$PIPX_BIN_DIR:$PATH
 RUN apt-get update && apt-get install -y pipx \
+    && rm -rf /var/lib/apt/lists/* \
     && pipx install poetry uv \
     # Preinstall common packages for each version
     && for pyv in $(ls ${PYENV_ROOT}/versions/); do \
@@ -173,7 +174,8 @@ RUN mkdir /tmp/swiftly \
 ### RUBY ###
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        ruby-full
+        ruby-full \
+    && rm -rf /var/lib/apt/lists/*
 
 ### RUST ###
 


### PR DESCRIPTION
It's somehow missing in some steps.

Summary from GitHub Copilot:

> This pull request optimizes the Dockerfile by improving image cleanliness and reducing its size. The changes ensure that temporary files created during package installation are removed to minimize the image's footprint.
> 
> ### Dockerfile optimizations:
> 
> * Added `rm -rf /var/lib/apt/lists/*` after installing `pipx` to clean up temporary files and reduce image size. (`[DockerfileR95](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R95)`)
> * Added `rm -rf /var/lib/apt/lists/*` after installing `ruby-full` to remove unnecessary files and maintain a clean image. (`[DockerfileL176-R178](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L176-R178)`)
