### PR TITLE
Add attestation to built images

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  attestations: write
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
@@ -27,9 +33,16 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
     - name: Build and push
+      id: docker_build
       uses: docker/build-push-action@v6
       with:
         push: true
         tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
         cache-from: type=gha
         cache-to: type=gha,mode=max
+    - name: Generate artifact attestation
+      uses: actions/attest-build-provenance@v2
+      with:
+        push-to-registry: true
+        subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        subject-digest: ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
This PR attaches an attestation to built docker images, letting anyone verify that the image came from the workflow.

From [the GitHub docs](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds):

> Artifact attestations enable you to create unfalsifiable provenance and integrity guarantees for the software you build. In turn, people who consume your software can verify where and how your software was built.
>
> When you generate artifact attestations with your software, you create cryptographically signed claims that establish your build's provenance and include the following information:
>
> A link to the workflow associated with the artifact.
The repository, organization, environment, commit SHA, and triggering event for the artifact.
Other information from the OIDC token used to establish provenance. For more information, see [About security hardening with OpenID Connect](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect).