### PR TITLE
Clean up nvm cache after node.js installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -119,6 +119,7 @@ RUN git -c advice.detachedHead=0 clone --branch ${NVM_VERSION} --depth 1 https:/
     && nvm install 18 \
     && nvm install 20 \
     && nvm install 22 \
+    && nvm cache clear \
     && nvm alias default $NODE_VERSION \
     && corepack enable \
     && corepack install -g yarn pnpm npm


### PR DESCRIPTION
This will save about ~100M from node.js tarball files.

---

Summary from GitHub Copilot:
 
> This pull request introduces a small but important change to the `Dockerfile` to optimize Node.js version management. It adds a step to clear the NVM cache after installing multiple Node.js versions.
> 
> * [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R122): Added `nvm cache clear` to ensure the cache is cleared after installing Node.js versions 18, 20, and 22, improving build efficiency and reducing potential conflicts.