### PR TITLE
Prevent leaving pip cache by using --no-cache-dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,7 +96,7 @@ RUN apt-get update && apt-get install -y pipx \
     && pipx install poetry uv \
     # Preinstall common packages for each version
     && for pyv in $(ls ${PYENV_ROOT}/versions/); do \
-        ${PYENV_ROOT}/versions/$pyv/bin/pip install --upgrade pip ruff black mypy pyright isort; \
+        ${PYENV_ROOT}/versions/$pyv/bin/pip install --no-cache-dir --upgrade pip ruff black mypy pyright isort; \
     done
 
 


### PR DESCRIPTION
This will save the image about ~100MB from the pip cache files.