### PR TITLE
Add Ruby support with rbenv for dynamic version switching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -173,9 +173,21 @@ RUN mkdir /tmp/swiftly \
 
 ### RUBY ###
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        ruby-full \
-    && rm -rf /var/lib/apt/lists/*
+ARG RBENV_VERSION=v1.3.2
+ARG RUBY_VERSION=3.2.3
+
+ENV RBENV_ROOT=/root/.rbenv
+ENV PATH=$RBENV_ROOT/bin:$RBENV_ROOT/shims:$PATH
+
+RUN apt-get update && apt-get install -y --no-install-recommends libyaml-dev \
+    && git -c advice.detachedHead=0 clone --branch ${RBENV_VERSION} --depth 1 https://github.com/rbenv/rbenv.git "${RBENV_ROOT}" \
+    && mkdir -p "${RBENV_ROOT}/plugins" \
+    && git -c advice.detachedHead=0 clone https://github.com/rbenv/ruby-build.git "${RBENV_ROOT}/plugins/ruby-build" \
+    && echo 'export RBENV_ROOT="$HOME/.rbenv"' >> /etc/profile \
+    && echo 'export PATH="$RBENV_ROOT/bin:$RBENV_ROOT/shims:$PATH"' >> /etc/profile \
+    && echo 'eval "$(rbenv init - bash)"' >> /etc/profile \
+    && rbenv install ${RUBY_VERSION} \
+    && rbenv global ${RUBY_VERSION}
 
 ### RUST ###
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ docker run --rm -it \
     # See below for environment variable options.
     -e CODEX_ENV_PYTHON_VERSION=3.12 \
     -e CODEX_ENV_NODE_VERSION=20 \
+    -e CODEX_ENV_RUBY_VERSION=3.2.8 \
     -e CODEX_ENV_RUST_VERSION=1.87.0 \
     -e CODEX_ENV_GO_VERSION=1.23.8 \
     -e CODEX_ENV_SWIFT_VERSION=6.1 \
@@ -39,6 +40,7 @@ The following environment variables can be set to configure runtime installation
 | -------------------------- | -------------------------- | ------------------------------------------------ | -------------------------------------------------------------------- |
 | `CODEX_ENV_PYTHON_VERSION` | Python version to install  | `3.10`, `3.11.12`, `3.12`, `3.13`                | `pyenv`, `poetry`, `uv`, `ruff`, `black`, `mypy`, `pyright`, `isort` |
 | `CODEX_ENV_NODE_VERSION`   | Node.js version to install | `18`, `20`, `22`                                 | `corepack`, `yarn`, `pnpm`, `npm`                                    |
+| `CODEX_ENV_RUBY_VERSION`   | Ruby version to install    | `3.2.8`, `3.3.8`, `3.4.4`                        |                                                                      |
 | `CODEX_ENV_RUST_VERSION`   | Rust version to install    | `1.83.0`, `1.84.1`, `1.85.1`, `1.86.0`, `1.87.0` |                                                                      |
 | `CODEX_ENV_GO_VERSION`     | Go version to install      | `1.22.12`, `1.23.8`, `1.24.3`                    |                                                                      |
 | `CODEX_ENV_SWIFT_VERSION`  | Swift version to install   | `5.10`, `6.1`                                    |                                                                      |
@@ -47,7 +49,6 @@ The following environment variables can be set to configure runtime installation
 
 In addition to the packages specified in the table above, the following packages are also installed:
 
-- `ruby`: 3.2.3
 - `bun`: 1.2.10
 - `java`: 21
 - `bazelisk` / `bazel`

--- a/setup_universal.sh
+++ b/setup_universal.sh
@@ -7,6 +7,7 @@ CODEX_ENV_NODE_VERSION=${CODEX_ENV_NODE_VERSION:-}
 CODEX_ENV_RUST_VERSION=${CODEX_ENV_RUST_VERSION:-}
 CODEX_ENV_GO_VERSION=${CODEX_ENV_GO_VERSION:-}
 CODEX_ENV_SWIFT_VERSION=${CODEX_ENV_SWIFT_VERSION:-}
+CODEX_ENV_RUBY_VERSION=${CODEX_ENV_RUBY_VERSION:-}
 
 echo "Configuring language runtimes..."
 
@@ -27,6 +28,15 @@ if [ -n "${CODEX_ENV_NODE_VERSION}" ]; then
     nvm use "${CODEX_ENV_NODE_VERSION}"
     corepack enable
     corepack install -g yarn pnpm npm
+fi
+
+if [ -n "${CODEX_ENV_RUBY_VERSION}" ]; then
+    current=$(ruby -v | awk '{print $2}' | cut -d'p' -f1)
+    echo "# Ruby: ${CODEX_ENV_RUBY_VERSION} (default: ${current})"
+    if [ "${current}" != "${CODEX_ENV_RUBY_VERSION}" ]; then
+        rbenv install -s "${CODEX_ENV_RUBY_VERSION}"
+        rbenv global "${CODEX_ENV_RUBY_VERSION}"
+    fi
 fi
 
 if [ -n "${CODEX_ENV_RUST_VERSION}" ]; then


### PR DESCRIPTION
Adds dynamic version switching for Ruby with rbenv for via `CODEX_ENV_RUBY_VERSION` environment variable. 

As an added benefit, rbenv automatically includes bundler for gem management.