### PR TITLE
fix: prevent codex webui hangs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,7 +98,7 @@ RUN apt-get update && apt-get install -y pipx \
     && for pyv in $(ls ${PYENV_ROOT}/versions/); do \
         ${PYENV_ROOT}/versions/$pyv/bin/pip install --upgrade pip ruff black mypy pyright isort; \
     done
-# prevents context pollution and console ui hanging with progress bar overload
+# Reduce the verbosity of uv - impacts performance of stdout buffering
 ENV UV_NO_PROGRESS=1
 
 ### NODE ###

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,7 +98,8 @@ RUN apt-get update && apt-get install -y pipx \
     && for pyv in $(ls ${PYENV_ROOT}/versions/); do \
         ${PYENV_ROOT}/versions/$pyv/bin/pip install --upgrade pip ruff black mypy pyright isort; \
     done
-
+# prevents context pollution and console ui hanging with progress bar overload
+ENV UV_NO_PROGRESS=1
 
 ### NODE ###
 


### PR DESCRIPTION
When using `uv` to sync dependencies, by default it uses a large amount of constantly refreshing progress bars.  This was overwhelming the codex web interface (and possibly polluting the LLM context)

https://docs.astral.sh/uv/reference/cli/#uv-run--no-progress