### PR TITLE
Add Elixir and Erlang support via mise to provide BEAM

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,15 @@
+{
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:elixir-lang.org)",
+      "Bash(docker build:*)",
+      "Bash(docker run:*)",
+      "Bash(-e CODEX_ENV_ERLANG_VERSION=26.2.5 )",
+      "Bash(-e CODEX_ENV_ELIXIR_VERSION=1.17.3 )",
+      "Bash(codex-universal )",
+      "Bash(bash:*)"
+    ],
+    "deny": []
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,58 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+`codex-universal` is a reference implementation of the base Docker image for OpenAI Codex environments. It provides a Ubuntu 24.04-based container with pre-installed development tools and runtime managers for multiple programming languages.
+
+## Architecture
+
+The project consists of:
+
+- **Dockerfile**: Multi-stage build that installs language runtimes and development tools
+- **setup_universal.sh**: Runtime configuration script that uses `CODEX_ENV_*` environment variables to set specific language versions
+- **entrypoint.sh**: Container entry point that runs setup and drops into a bash shell
+
+Language runtime management is handled by dedicated version managers:
+- Python: pyenv with versions 3.10, 3.11.12, 3.12, 3.13
+- Node.js: nvm with versions 18, 20, 22
+- Rust: rustup (configurable via environment)
+- Go: manual installation with configurable versions
+- Swift: swiftly with configurable versions
+- Erlang/Elixir: mise with any supported versions (Elixir automatically uses compatible OTP version)
+
+## Common Commands
+
+### Building the Docker image
+```bash
+docker build -t codex-universal .
+```
+
+### Running the container locally
+```bash
+docker run --rm -it \
+    -e CODEX_ENV_PYTHON_VERSION=3.12 \
+    -e CODEX_ENV_NODE_VERSION=20 \
+    -v $(pwd):/workspace/$(basename $(pwd)) \
+    -w /workspace/$(basename $(pwd)) \
+    codex-universal
+```
+
+### Testing different language versions
+Set environment variables before running:
+- `CODEX_ENV_PYTHON_VERSION`: 3.10, 3.11.12, 3.12, 3.13
+- `CODEX_ENV_NODE_VERSION`: 18, 20, 22
+- `CODEX_ENV_RUST_VERSION`: 1.83.0, 1.84.1, 1.85.1, 1.86.0, 1.87.0
+- `CODEX_ENV_GO_VERSION`: 1.22.12, 1.23.8, 1.24.3
+- `CODEX_ENV_SWIFT_VERSION`: 5.10, 6.1
+- `CODEX_ENV_ERLANG_VERSION`: Any mise-supported version (e.g., 27.1.2, 26.2.5)
+- `CODEX_ENV_ELIXIR_VERSION`: Any mise-supported version (e.g., 1.18.3, 1.17.3)
+
+## Development Notes
+
+- The setup script uses runtime version managers to switch between language versions rather than installing multiple system-wide versions
+- Each language runtime includes common development tools (linters, formatters, package managers)
+- Elixir installations automatically use compatible Erlang OTP versions (e.g., elixir@1.18.3-otp-27)
+- mise is used for Erlang/Elixir version management and supports any versions available in the mise ecosystem
+- The image is designed to approximate the OpenAI Codex environment for local development and debugging

--- a/Dockerfile
+++ b/Dockerfile
@@ -221,6 +221,39 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
 
+### MISE (for Elixir/Erlang) ###
+
+ARG ERLANG_VERSION=27.1.2
+ARG ELIXIR_VERSION=1.18.3
+
+ENV MISE_DATA_DIR=/root/.local/share/mise
+ENV PATH=/root/.local/bin:$PATH
+
+# Install mise, then Erlang dependencies and Erlang/Elixir
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        autoconf \
+        automake \
+        libtool \
+        libwxgtk3.2-dev \
+        libgl1-mesa-dev \
+        libglu1-mesa-dev \
+        libpng-dev \
+        libssh-dev \
+        libncurses5-dev \
+        libodbc2 \
+        unixodbc-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl https://mise.run | sh \
+    && echo 'eval "$(~/.local/bin/mise activate bash)"' >> /etc/profile
+
+# Install Erlang and Elixir with mise in a bash shell
+RUN bash -c 'eval "$(~/.local/bin/mise activate bash)" \
+    && mise install erlang@${ERLANG_VERSION} \
+    && mise use --global erlang@${ERLANG_VERSION} \
+    && eval "$(~/.local/bin/mise activate bash)" \
+    && mise install elixir@${ELIXIR_VERSION}-otp-27 \
+    && mise use --global elixir@${ELIXIR_VERSION}-otp-27'
+
 ### SETUP SCRIPTS ###
 
 COPY setup_universal.sh /opt/codex/setup_universal.sh

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ docker run --rm -it \
     -e CODEX_ENV_RUST_VERSION=1.87.0 \
     -e CODEX_ENV_GO_VERSION=1.23.8 \
     -e CODEX_ENV_SWIFT_VERSION=6.1 \
+    -e CODEX_ENV_ERLANG_VERSION=27.1.2 \
+    -e CODEX_ENV_ELIXIR_VERSION=1.18.3 \
     # Mount the current directory similar to how it would get cloned in.
     -v $(pwd):/workspace/$(basename $(pwd)) -w /workspace/$(basename $(pwd)) \
     ghcr.io/openai/codex-universal:latest
@@ -35,13 +37,15 @@ docker run --rm -it \
 
 The following environment variables can be set to configure runtime installation. Note that a limited subset of versions are supported (indicated in the table below):
 
-| Environment variable       | Description                | Supported versions                               | Additional packages                                                  |
-| -------------------------- | -------------------------- | ------------------------------------------------ | -------------------------------------------------------------------- |
-| `CODEX_ENV_PYTHON_VERSION` | Python version to install  | `3.10`, `3.11.12`, `3.12`, `3.13`                | `pyenv`, `poetry`, `uv`, `ruff`, `black`, `mypy`, `pyright`, `isort` |
-| `CODEX_ENV_NODE_VERSION`   | Node.js version to install | `18`, `20`, `22`                                 | `corepack`, `yarn`, `pnpm`, `npm`                                    |
-| `CODEX_ENV_RUST_VERSION`   | Rust version to install    | `1.83.0`, `1.84.1`, `1.85.1`, `1.86.0`, `1.87.0` |                                                                      |
-| `CODEX_ENV_GO_VERSION`     | Go version to install      | `1.22.12`, `1.23.8`, `1.24.3`                    |                                                                      |
-| `CODEX_ENV_SWIFT_VERSION`  | Swift version to install   | `5.10`, `6.1`                                    |                                                                      |
+| Environment variable        | Description                 | Supported versions                               | Additional packages                                                  |
+| --------------------------- | --------------------------- | ------------------------------------------------ | -------------------------------------------------------------------- |
+| `CODEX_ENV_PYTHON_VERSION`  | Python version to install  | `3.10`, `3.11.12`, `3.12`, `3.13`                | `pyenv`, `poetry`, `uv`, `ruff`, `black`, `mypy`, `pyright`, `isort` |
+| `CODEX_ENV_NODE_VERSION`    | Node.js version to install | `18`, `20`, `22`                                 | `corepack`, `yarn`, `pnpm`, `npm`                                    |
+| `CODEX_ENV_RUST_VERSION`    | Rust version to install    | `1.83.0`, `1.84.1`, `1.85.1`, `1.86.0`, `1.87.0` |                                                                      |
+| `CODEX_ENV_GO_VERSION`      | Go version to install      | `1.22.12`, `1.23.8`, `1.24.3`                    |                                                                      |
+| `CODEX_ENV_SWIFT_VERSION`   | Swift version to install   | `5.10`, `6.1`                                    |                                                                      |
+| `CODEX_ENV_ERLANG_VERSION`  | Erlang version to install  | Any version supported by mise (e.g., `27.1.2`, `26.2.5`) | `mise` version manager                              |
+| `CODEX_ENV_ELIXIR_VERSION`  | Elixir version to install  | Any version supported by mise (e.g., `1.18.3`, `1.17.3`) | `mise` version manager, automatically matched with Erlang OTP |
 
 ## What's included
 

--- a/setup_universal.sh
+++ b/setup_universal.sh
@@ -7,6 +7,8 @@ CODEX_ENV_NODE_VERSION=${CODEX_ENV_NODE_VERSION:-}
 CODEX_ENV_RUST_VERSION=${CODEX_ENV_RUST_VERSION:-}
 CODEX_ENV_GO_VERSION=${CODEX_ENV_GO_VERSION:-}
 CODEX_ENV_SWIFT_VERSION=${CODEX_ENV_SWIFT_VERSION:-}
+CODEX_ENV_ERLANG_VERSION=${CODEX_ENV_ERLANG_VERSION:-}
+CODEX_ENV_ELIXIR_VERSION=${CODEX_ENV_ELIXIR_VERSION:-}
 
 echo "Configuring language runtimes..."
 
@@ -58,5 +60,30 @@ if [ -n "${CODEX_ENV_SWIFT_VERSION}" ]; then
     echo "# Swift: ${CODEX_ENV_SWIFT_VERSION} (default: ${current})"
     if [ "${current}" != "${CODEX_ENV_SWIFT_VERSION}" ]; then
         swiftly install --use "${CODEX_ENV_SWIFT_VERSION}"
+    fi
+fi
+
+if [ -n "${CODEX_ENV_ERLANG_VERSION}" ]; then
+    # Activate mise for this shell session
+    eval "$(~/.local/bin/mise activate bash)"
+    current=$(mise current erlang 2>/dev/null || echo "none")
+    echo "# Erlang: ${CODEX_ENV_ERLANG_VERSION} (default: ${current})"
+    if [ "${current}" != "${CODEX_ENV_ERLANG_VERSION}" ]; then
+        mise install erlang@"${CODEX_ENV_ERLANG_VERSION}"
+        mise use --global erlang@"${CODEX_ENV_ERLANG_VERSION}"
+    fi
+fi
+
+if [ -n "${CODEX_ENV_ELIXIR_VERSION}" ]; then
+    # Activate mise for this shell session
+    eval "$(~/.local/bin/mise activate bash)"
+    current=$(mise current elixir 2>/dev/null | cut -d'-' -f1 || echo "none")
+    echo "# Elixir: ${CODEX_ENV_ELIXIR_VERSION} (default: ${current})"
+    if [ "${current}" != "${CODEX_ENV_ELIXIR_VERSION}" ]; then
+        # Determine OTP version for Elixir installation
+        erlang_version=$(mise current erlang 2>/dev/null || echo "27")
+        otp_version=$(echo "$erlang_version" | cut -d'.' -f1)
+        mise install elixir@"${CODEX_ENV_ELIXIR_VERSION}"-otp-"${otp_version}"
+        mise use --global elixir@"${CODEX_ENV_ELIXIR_VERSION}"-otp-"${otp_version}"
     fi
 fi


### PR DESCRIPTION
Add Elixir and Erlang support via mise to provide BEAM  ecosystem language runtimes alongside existing multi-language development environment.

Also, uses mise for version management, which might theoretically be an easy path to supporting many languages and packages