### PR TITLE
Add .NET SDK 9.0 Support to Docker Image and Update Documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -221,6 +221,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
 
+### DOTNET ###
+
+ARG DOTNET_VERSION=9.0
+ENV DOTNET_ROOT=/root/.dotnet
+ENV PATH=$DOTNET_ROOT:$PATH
+RUN apt-get update && apt-get install -y --no-install-recommends wget \
+    && wget https://dot.net/v1/dotnet-install.sh -O /tmp/dotnet-install.sh \
+    && chmod +x /tmp/dotnet-install.sh \
+    && /tmp/dotnet-install.sh --channel "$DOTNET_VERSION" --install-dir "$DOTNET_ROOT" \
+    && rm /tmp/dotnet-install.sh \
+    && echo 'export DOTNET_ROOT=/root/.dotnet' >> /etc/profile \
+    && echo 'export PATH=/root/.dotnet:$PATH' >> /etc/profile \
+    && dotnet --version
 ### SETUP SCRIPTS ###
 
 COPY setup_universal.sh /opt/codex/setup_universal.sh

--- a/README.md
+++ b/README.md
@@ -14,36 +14,32 @@ The Docker image is available at:
 docker pull ghcr.io/openai/codex-universal:latest
 ```
 
-The below script shows how can you approximate the `setup` environment in Codex:
+The below script shows how you can run the image locally:
 
 ```
 docker run --rm -it \
-    # See below for environment variable options.
-    -e CODEX_ENV_PYTHON_VERSION=3.12 \
-    -e CODEX_ENV_NODE_VERSION=20 \
-    -e CODEX_ENV_RUST_VERSION=1.87.0 \
-    -e CODEX_ENV_GO_VERSION=1.23.8 \
-    -e CODEX_ENV_SWIFT_VERSION=6.1 \
-    -e CODEX_ENV_DOTNET_VERSION=9.0 \
-    # Mount the current directory similar to how it would get cloned in.
     -v $(pwd):/workspace/$(basename $(pwd)) -w /workspace/$(basename $(pwd)) \
     ghcr.io/openai/codex-universal:latest
 ```
 
-`codex-universal` includes setup scripts that look for `CODEX_ENV_*` environment variables and configures the language version accordingly.
+To build the image with a specific language version, use the `--build-arg` flag with `docker build`. For example, to build with .NET 9.0:
+
+```
+docker build --build-arg DOTNET_VERSION=9.0 -t myimage .
+```
 
 ### Configuring language runtimes
 
-The following environment variables can be set to configure runtime installation. Note that a limited subset of versions are supported (indicated in the table below):
+The following build arguments can be set to configure which version is installed (see the Dockerfile for all options):
 
-| Environment variable       | Description                | Supported versions                               | Additional packages                                                  |
-| -------------------------- | -------------------------- | ------------------------------------------------ | -------------------------------------------------------------------- |
-| `CODEX_ENV_PYTHON_VERSION` | Python version to install  | `3.10`, `3.11.12`, `3.12`, `3.13`                | `pyenv`, `poetry`, `uv`, `ruff`, `black`, `mypy`, `pyright`, `isort` |
-| `CODEX_ENV_NODE_VERSION`   | Node.js version to install | `18`, `20`, `22`                                 | `corepack`, `yarn`, `pnpm`, `npm`                                    |
-| `CODEX_ENV_RUST_VERSION`   | Rust version to install    | `1.83.0`, `1.84.1`, `1.85.1`, `1.86.0`, `1.87.0` |                                                                      |
-| `CODEX_ENV_GO_VERSION`     | Go version to install      | `1.22.12`, `1.23.8`, `1.24.3`                    |                                                                      |
-| `CODEX_ENV_SWIFT_VERSION`  | Swift version to install   | `5.10`, `6.1`                                    |                                                                      |
-| `CODEX_ENV_DOTNET_VERSION`  | .NET SDK version to install    | `9.0`                                         |                                                                  |
+| Build argument      | Description                | Supported versions                               |
+| -------------------| -------------------------- | ------------------------------------------------ |
+| `PYTHON_VERSION`   | Python version to install  | `3.10`, `3.11.12`, `3.12`, `3.13`                |
+| `NODE_VERSION`     | Node.js version to install | `18`, `20`, `22`                                 |
+| `RUST_VERSION`     | Rust version to install    | `1.83.0`, `1.84.1`, `1.85.1`, `1.86.0`, `1.87.0` |
+| `GO_VERSION`       | Go version to install      | `1.22.12`, `1.23.8`, `1.24.3`                    |
+| `SWIFT_VERSION`    | Swift version to install   | `5.10`, `6.1`                                    |
+| `DOTNET_VERSION`   | .NET SDK version to install| `9.0`                                            |
 
 ## What's included
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,13 @@ docker run --rm -it \
     ghcr.io/openai/codex-universal:latest
 ```
 
-To build the image with a specific language version, use the `--build-arg` flag with `docker build`. For example, to build with .NET 9.0:
+To build the image with a specific language version, use the `--build-arg` flag with `docker build`. For example, to build with the latest supported Python version (3.13):
+
+```
+docker build --build-arg PYTHON_VERSION=3.13 -t myimage .
+```
+
+Or, to build with .NET 9.0:
 
 ```
 docker build --build-arg DOTNET_VERSION=9.0 -t myimage .

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ docker run --rm -it \
     -e CODEX_ENV_RUST_VERSION=1.87.0 \
     -e CODEX_ENV_GO_VERSION=1.23.8 \
     -e CODEX_ENV_SWIFT_VERSION=6.1 \
+    -e CODEX_ENV_DOTNET_VERSION=9.0 \
     # Mount the current directory similar to how it would get cloned in.
     -v $(pwd):/workspace/$(basename $(pwd)) -w /workspace/$(basename $(pwd)) \
     ghcr.io/openai/codex-universal:latest
@@ -42,6 +43,7 @@ The following environment variables can be set to configure runtime installation
 | `CODEX_ENV_RUST_VERSION`   | Rust version to install    | `1.83.0`, `1.84.1`, `1.85.1`, `1.86.0`, `1.87.0` |                                                                      |
 | `CODEX_ENV_GO_VERSION`     | Go version to install      | `1.22.12`, `1.23.8`, `1.24.3`                    |                                                                      |
 | `CODEX_ENV_SWIFT_VERSION`  | Swift version to install   | `5.10`, `6.1`                                    |                                                                      |
+| `CODEX_ENV_DOTNET_VERSION`  | .NET SDK version to install    | `9.0`                                         |                                                                  |
 
 ## What's included
 
@@ -51,5 +53,6 @@ In addition to the packages specified in the table above, the following packages
 - `bun`: 1.2.10
 - `java`: 21
 - `bazelisk` / `bazel`
+- `dotnet`: 9.0
 
 See [Dockerfile](Dockerfile) for the full details of installed packages.


### PR DESCRIPTION
This pull request introduces support for the .NET SDK (version 9.0) in the Docker image and updates the documentation to reflect this addition. The most important changes include modifications to the `Dockerfile` to install .NET, updates to the `README.md` to explain how to build the image with .NET and other language versions, and adjustments to the runtime configuration documentation.

### Support for .NET SDK:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R224-R236): Added installation steps for the .NET SDK (version 9.0), including setting up environment variables (`DOTNET_ROOT` and `PATH`) and verifying the installation.

### Documentation Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L17-R48): Updated the instructions for running the Docker image locally, replacing environment variable examples with build argument examples for language versions. Added examples for building the image with specific versions of Python and .NET.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L17-R48): Updated the runtime configuration table to reflect the switch from environment variables to build arguments and added `.NET SDK` as a supported runtime.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R58): Included `.NET SDK (9.0)` in the list of additional installed packages.