### PR TITLE
Add Go 1.25.1 to supported Go versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -240,7 +240,7 @@ RUN curl -L --fail https://github.com/bazelbuild/bazelisk/releases/download/${BA
 
 ### GO ###
 
-ARG GO_VERSIONS="1.24.3 1.23.8 1.22.12"
+ARG GO_VERSIONS="1.25.1 1.24.3 1.23.8 1.22.12"
 ARG GOLANG_CI_LINT_VERSION=2.1.6
 
 # Go defaults GOROOT to /usr/local/go - we just need to update PATH

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The following environment variables can be set to configure runtime installation
 | `CODEX_ENV_PYTHON_VERSION` | Python version to install  | `3.10`, `3.11.12`, `3.12`, `3.13`                | `pyenv`, `poetry`, `uv`, `ruff`, `black`, `mypy`, `pyright`, `isort` |
 | `CODEX_ENV_NODE_VERSION`   | Node.js version to install | `18`, `20`, `22`                                 | `corepack`, `yarn`, `pnpm`, `npm`                                    |
 | `CODEX_ENV_RUST_VERSION`   | Rust version to install    | `1.83.0`, `1.84.1`, `1.85.1`, `1.86.0`, `1.87.0` |                                                                      |
-| `CODEX_ENV_GO_VERSION`     | Go version to install      | `1.22.12`, `1.23.8`, `1.24.3`                    |                                                                      |
+| `CODEX_ENV_GO_VERSION`     | Go version to install      | `1.22.12`, `1.23.8`, `1.24.3`, `1.25.1`           |                                                                      |
 | `CODEX_ENV_SWIFT_VERSION`  | Swift version to install   | `5.10`, `6.1`                                    |                                                                      |
 | `CODEX_ENV_RUBY_VERSION`   | Ruby version to install  | `3.2.3`, `3.3.8`, `3.4.4`                |                                                                      |
 | `CODEX_ENV_PHP_VERSION`   | PHP version to install  | `8.4`, `8.3`, `8.2`                |                                                                      |


### PR DESCRIPTION
This PR adds official support for Go 1.25.1 to the Codex Universal Docker image.  
**Closes \#85.**

### **Changes**

* Updates the `GO_VERSIONS` list in the Dockerfile to include Go 1.25.1 as the default.  
* Ensures developers can use Go 1.25.1 via `CODEX_ENV_GO_VERSION=1.25.1`.

### **Why?**

Go 1.25 brings several important improvements:

* **Container-aware GOMAXPROCS** (respects cgroup CPU bandwidth limits and updates automatically)  
* Experimental features: redesigned garbage collector (`GOEXPERIMENT=greenteagc`), modernized JSON implementation (`GOEXPERIMENT=jsonv2`), and more efficient debug info via DWARF 5

See [Go 1.25 Release Notes](https://musical-doodle-7jqjrq5xjg3pwjq.github.dev/) for details.
