### PR TITLE
Add Swift 6.2 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN apt-get update \
         liblzma-dev=5.6.* \
         libncurses-dev=6.4+20240113-* \
         libnss3-dev=2:3.98-* \
-        libpq-dev=16.9-* \
+        libpq-dev=16.10-* \
         libpsl-dev=0.21.* \
         libpython3-dev=3.12.* \
         libreadline-dev=8.2-* \
@@ -191,7 +191,7 @@ RUN JAVA_VERSIONS="$( [ "$TARGETARCH" = "arm64" ] && echo "$ARM_JAVA_VERSIONS" |
 
 ### SWIFT ###
 
-ARG SWIFT_VERSIONS="6.1 5.10.1"
+ARG SWIFT_VERSIONS="6.2 6.1 5.10.1"
 # mise currently broken for swift on ARM
 RUN if [ "$TARGETARCH" = "amd64" ]; then \
       for v in $SWIFT_VERSIONS; do \
@@ -264,7 +264,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libjpeg-dev=8c-* \
         libonig-dev=6.9.* \
         libpng-dev=1.6.* \
-        libpq-dev=16.9-* \
+        libpq-dev=16.10-* \
         libzip-dev=1.7.* \
         openssl=3.0.* \
         re2c=3.1-* \

--- a/LICENSES/codex-universal-image-sbom.md
+++ b/LICENSES/codex-universal-image-sbom.md
@@ -84,7 +84,7 @@ Generated for the OpenAI dev Docker image
 | go | 1.23.8 | https://golang.org/dl/ | curl+tar | BSD-3-Clause |
 | gradle | 8.14 | https://services.gradle.org | curl+unzip | Apache-2.0 |
 | bazelisk | 1.26.0 | https://github.com/bazelbuild/bazelisk | curl | Apache-2.0 |
-| swift | 6.1 | https://swift.org | swiftly script | Apache-2.0 |
+| swift | 6.2 | https://swift.org | swiftly script | Apache-2.0 |
 | llvm | latest | https://apt.llvm.org/llvm.sh | custom script | Apache-2.0 with LLVM exceptions |
 | pyenv | v2.5.5 | https://github.com/pyenv/pyenv | git clone | MIT |
 | nvm | v0.40.2 | https://github.com/nvm-sh/nvm | git clone | MIT |

--- a/LICENSES/codex-universal-image-sbom.spdx.json
+++ b/LICENSES/codex-universal-image-sbom.spdx.json
@@ -825,7 +825,7 @@
     {
       "name": "swift",
       "SPDXID": "SPDXRef-Package-swift",
-      "versionInfo": "6.1",
+      "versionInfo": "6.2",
       "downloadLocation": "https://swift.org",
       "licenseConcluded": "Apache-2.0",
       "licenseDeclared": "Apache-2.0",

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ docker run --rm -it \
     -e CODEX_ENV_NODE_VERSION=20 \
     -e CODEX_ENV_RUST_VERSION=1.87.0 \
     -e CODEX_ENV_GO_VERSION=1.23.8 \
-    -e CODEX_ENV_SWIFT_VERSION=6.1 \
+    -e CODEX_ENV_SWIFT_VERSION=6.2 \
     -e CODEX_ENV_RUBY_VERSION=3.4.4 \
     -e CODEX_ENV_PHP_VERSION=8.4 \
     -v $(pwd):/workspace/$(basename $(pwd)) -w /workspace/$(basename $(pwd)) \
@@ -50,7 +50,7 @@ The following environment variables can be set to configure runtime installation
 | `CODEX_ENV_NODE_VERSION`   | Node.js version to install | `18`, `20`, `22`                                 | `corepack`, `yarn`, `pnpm`, `npm`                                    |
 | `CODEX_ENV_RUST_VERSION`   | Rust version to install    | `1.83.0`, `1.84.1`, `1.85.1`, `1.86.0`, `1.87.0` |                                                                      |
 | `CODEX_ENV_GO_VERSION`     | Go version to install      | `1.22.12`, `1.23.8`, `1.24.3`                    |                                                                      |
-| `CODEX_ENV_SWIFT_VERSION`  | Swift version to install   | `5.10`, `6.1`                                    |                                                                      |
+| `CODEX_ENV_SWIFT_VERSION`  | Swift version to install   | `5.10`, `6.1`, `6.2`                              |                                                                      |
 | `CODEX_ENV_RUBY_VERSION`   | Ruby version to install  | `3.2.3`, `3.3.8`, `3.4.4`                |                                                                      |
 | `CODEX_ENV_PHP_VERSION`   | PHP version to install  | `8.4`, `8.3`, `8.2`                |                                                                      |
 

--- a/setup_universal.sh
+++ b/setup_universal.sh
@@ -58,7 +58,7 @@ if [ -n "${CODEX_ENV_GO_VERSION}" ]; then
 fi
 
 if [ -n "${CODEX_ENV_SWIFT_VERSION}" ]; then
-    current=$(swift --version | sed -n 's/^Swift version \([0-9]\+\.[0-9]\+\).*/\1/p')   # ==> 6.1
+    current=$(swift --version | sed -n 's/^Swift version \([0-9]\+\.[0-9]\+\).*/\1/p')   # ==> 6.2
     echo "# Swift: ${CODEX_ENV_SWIFT_VERSION} (default: ${current})"
     if [ "${current}" != "${CODEX_ENV_SWIFT_VERSION}" ]; then
         mise use --global "swift@${CODEX_ENV_SWIFT_VERSION}"


### PR DESCRIPTION
## Summary
I'm working on a Swift package that targets Swift 6.2, so I added first-class support for that toolchain. Swift 6.2 became an officially supported release on September 15, 2025, so the image now installs it by default alongside earlier versions. Details: https://www.swift.org/blog/swift-6.2-released/

## Changes
- install Swift 6.2 on amd64 builds while keeping 6.1 and 5.10.1 available via mise
- update setup scripts and documentation to list Swift 6.2 as a supported selectable version
- refresh SBOM metadata for the Swift package version
- bump the pinned libpq-dev dependency to 16.10-* so apt still resolves

## Testing
- docker build --platform linux/amd64 -t codex-universal:swift-6.2 . --progress=plain
