### PR TITLE
feat: add .NET SDK (C#) support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -207,6 +207,38 @@ RUN --mount=type=cache,target=/root/.cache/mise \
     && mise use --global "maven@${MAVEN_VERSION}" \
     && mise cache clear || true
 
+### DOTNET ###
+
+# Install .NET SDKs for C# development. We keep them side-by-side under /opt/dotnet/<channel>
+# and provide a small wrapper at /usr/local/bin/dotnet that selects a default.
+ARG DOTNET_VERSIONS="10.0 9.0 8.0"
+
+RUN --mount=type=cache,target=/root/.cache/dotnet \
+    mkdir -p /opt/dotnet /opt/codex \
+    && curl -fsSL https://dot.net/v1/dotnet-install.sh -o /usr/local/bin/dotnet-install.sh \
+    && chmod +x /usr/local/bin/dotnet-install.sh \
+    && for v in $DOTNET_VERSIONS; do \
+         /usr/local/bin/dotnet-install.sh --channel "$v" --install-dir "/opt/dotnet/${v}" --no-path; \
+       done \
+    && echo "${DOTNET_VERSIONS%% *}" > /opt/codex/dotnet_default \
+    && printf '%s\n' \
+        '#!/bin/sh' \
+        'set -eu' \
+        '' \
+        'default_file="/opt/codex/dotnet_default"' \
+        'v=""' \
+        'if [ -f "$default_file" ]; then' \
+        '  v="$(cat "$default_file" 2>/dev/null || true)"' \
+        'fi' \
+        'if [ -z "$v" ]; then' \
+        '  v="10.0"' \
+        'fi' \
+        '' \
+        'export DOTNET_ROOT="/opt/dotnet/$v"' \
+        'exec "$DOTNET_ROOT/dotnet" "$@"' \
+      > /usr/local/bin/dotnet \
+    && chmod +x /usr/local/bin/dotnet
+
 ### SWIFT ###
 
 ARG SWIFT_VERSIONS="6.2 6.1 5.10"
@@ -329,6 +361,7 @@ RUN chmod +x /opt/verify.sh \
         NODE_VERSIONS="24 22 20 18" \
         RUST_VERSIONS="$RUST_VERSIONS" \
         GO_VERSIONS="$GO_VERSIONS" \
+        DOTNET_VERSIONS="$DOTNET_VERSIONS" \
         SWIFT_VERSIONS="$SWIFT_VERSIONS" \
         RUBY_VERSIONS="$RUBY_VERSIONS" \
         PHP_VERSIONS="$PHP_VERSIONS" \

--- a/LICENSES/LICENSE
+++ b/LICENSES/LICENSE
@@ -24,7 +24,7 @@ SOFTWARE.
 The Docker image incorporates a variety of open source components, including but not limited to:
 
 - Base system: Ubuntu 24.04
-- Languages: Python, Node.js, Ruby, Go, Rust, Java (OpenJDK), Swift
+- Languages: Python, Node.js, Ruby, Go, Rust, Java (OpenJDK), Swift, .NET (C#)
 - Developer tools: Poetry, Bun, Gradle, LLVM, pipx, pyenv, and others
 
 These components are governed by licenses such as:

--- a/LICENSES/codex-universal-image-sbom.md
+++ b/LICENSES/codex-universal-image-sbom.md
@@ -91,6 +91,7 @@ Generated for the OpenAI dev Docker image
 | Python | 3.10, 3.11.12, 3.12, 3.13 | https://www.python.org | pyenv | Python-2.0 |
 | Node.js | 18, 20, 22 | https://nodejs.org | nvm | MIT |
 | Java | OpenJDK 21 | https://openjdk.org | apt | GPL-2.0 with Classpath Exception |
+| .NET SDK | 8.0, 9.0, 10.0 | https://dotnet.microsoft.com | dotnet-install.sh | MIT |
 | Ruby | system default | https://www.ruby-lang.org | apt | Ruby / BSD dual-license |
 | Rust | stable | https://www.rust-lang.org | rustup | MIT OR Apache-2.0 |
 | poetry | latest | https://python-poetry.org | pipx | MIT |

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ docker run --rm -it \
     -e CODEX_ENV_NODE_VERSION=20 \
     -e CODEX_ENV_RUST_VERSION=1.87.0 \
     -e CODEX_ENV_GO_VERSION=1.23.8 \
+    -e CODEX_ENV_DOTNET_VERSION=8.0 \
     -e CODEX_ENV_SWIFT_VERSION=6.2 \
     -e CODEX_ENV_RUBY_VERSION=3.4.4 \
     -e CODEX_ENV_PHP_VERSION=8.4 \
@@ -50,6 +51,7 @@ The following environment variables can be set to configure runtime installation
 | `CODEX_ENV_NODE_VERSION`   | Node.js version to install | `18`, `20`, `22`                                 | `corepack`, `yarn`, `pnpm`, `npm`                                    |
 | `CODEX_ENV_RUST_VERSION`   | Rust version to install    | `1.83.0`, `1.84.1`, `1.85.1`, `1.86.0`, `1.87.0`, `1.88.0`, `1.89.0`, `1.90`, `1.91.1`, `1.92.0` |                                                                      |
 | `CODEX_ENV_GO_VERSION`     | Go version to install      | `1.22.12`, `1.23.8`, `1.24.3`, `1.25.1`           |                                                                      |
+| `CODEX_ENV_DOTNET_VERSION` | .NET SDK channel to use    | `10.0`, `9.0`, `8.0`                              |                                                                      |
 | `CODEX_ENV_SWIFT_VERSION`  | Swift version to install   | `5.10`, `6.1`, `6.2`                              |                                                                      |
 | `CODEX_ENV_RUBY_VERSION`   | Ruby version to install  | `3.2.3`, `3.3.8`, `3.4.4`                |                                                                      |
 | `CODEX_ENV_PHP_VERSION`   | PHP version to install  | `8.4`, `8.3`, `8.2`                |                                                                      |

--- a/setup_universal.sh
+++ b/setup_universal.sh
@@ -10,6 +10,7 @@ CODEX_ENV_GO_VERSION=${CODEX_ENV_GO_VERSION:-}
 CODEX_ENV_SWIFT_VERSION=${CODEX_ENV_SWIFT_VERSION:-}
 CODEX_ENV_PHP_VERSION=${CODEX_ENV_PHP_VERSION:-}
 CODEX_ENV_JAVA_VERSION=${CODEX_ENV_JAVA_VERSION:-}
+CODEX_ENV_DOTNET_VERSION=${CODEX_ENV_DOTNET_VERSION:-}
 
 echo "Configuring language runtimes..."
 
@@ -88,4 +89,17 @@ if [ -n "${CODEX_ENV_JAVA_VERSION}" ]; then
         mise use --global "java@${CODEX_ENV_JAVA_VERSION}"
         java -version
     fi
+fi
+
+if [ -n "${CODEX_ENV_DOTNET_VERSION}" ]; then
+    current="$(dotnet --version | cut -d. -f1,2)"   # ==> 10.0
+    echo "# .NET SDK: ${CODEX_ENV_DOTNET_VERSION} (default: ${current})"
+    if [ ! -d "/opt/dotnet/${CODEX_ENV_DOTNET_VERSION}" ]; then
+        echo "Requested .NET SDK version is not installed: ${CODEX_ENV_DOTNET_VERSION}" >&2
+        echo "Installed SDK channels:" >&2
+        ls -1 /opt/dotnet >&2 || true
+        exit 1
+    fi
+    echo "${CODEX_ENV_DOTNET_VERSION}" > /opt/codex/dotnet_default
+    dotnet --version
 fi

--- a/verify.sh
+++ b/verify.sh
@@ -8,6 +8,7 @@ read -ra PYTHON <<< "$PYTHON_VERSIONS"
 read -ra NODE   <<< "$NODE_VERSIONS"
 read -ra RUST   <<< "$RUST_VERSIONS"
 read -ra GO     <<< "$GO_VERSIONS"
+read -ra DOTNET <<< "$DOTNET_VERSIONS"
 read -ra SWIFT  <<< "$SWIFT_VERSIONS"
 read -ra RUBY   <<< "$RUBY_VERSIONS"
 read -ra PHP    <<< "$PHP_VERSIONS"
@@ -18,6 +19,7 @@ max=$(printf "%s\n" \
   ${#NODE[@]} \
   ${#RUST[@]} \
   ${#GO[@]} \
+  ${#DOTNET[@]} \
   ${#SWIFT[@]} \
   ${#RUBY[@]} \
   ${#PHP[@]} \
@@ -29,6 +31,7 @@ for ((i=max-1; i>=0; i--)); do
   CODEX_ENV_NODE_VERSION=${NODE[i]:-${NODE[0]}} \
   CODEX_ENV_RUST_VERSION=${RUST[i]:-${RUST[0]}} \
   CODEX_ENV_GO_VERSION=${GO[i]:-${GO[0]}} \
+  CODEX_ENV_DOTNET_VERSION=${DOTNET[i]:-${DOTNET[0]}} \
   CODEX_ENV_SWIFT_VERSION=${SWIFT[i]:-${SWIFT[0]}} \
   CODEX_ENV_RUBY_VERSION=${RUBY[i]:-${RUBY[0]}} \
   CODEX_ENV_PHP_VERSION=${PHP[i]:-${PHP[0]}} \
@@ -60,6 +63,10 @@ java -version
 javac -version
 gradle --version | head -n 3
 mvn --version | head -n 1
+
+echo "- .NET:"
+dotnet --version
+dotnet --list-sdks
 
 echo "- Swift:"
 swift --version


### PR DESCRIPTION
**Summary:**

- Adds .NET SDK channels `8.0`, `9.0`, `10.0` to the image (installed under `/opt/dotnet/<channel>`).
- Introduces `CODEX_ENV_DOTNET_VERSION` to select the default SDK at startup via `/opt/codex/setup_universal.sh`.
- Extends `/opt/verify.sh` to validate .NET switching and report `dotnet --version` / `dotnet --list-sdks`.
- Updates docs and SBOM to mention .NET.